### PR TITLE
Fixed cue execution command

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ instance.prototype.action = function(action) {
 	switch (action.action){
 
 		case 'cue_exec':
-			cmd = '<photon> CUE_EXEC '+ opt.cue + ' </photon>';
+			cmd = '<photon> CUE_EXEC_ID '+ opt.cue + ' </photon>';
 			break;
 
 	};


### PR DESCRIPTION
Hello Per!

I am a researcher and software developer at VYV and I came across your implementation. Very glad that you implemented support for our software! However, I saw a small mistake in the command that is sent. The "CUE_EXEC" command is rather old and can be a bit dangerous since it depends on the cue list ordering. This command has been deprecated and replaced with "CUE_EXEC_ID" which executes a cue given its ID. I am available if you need more precision.

We plan on buying a Stream Deck and I will to send you further updates for a better interoperability between our two softwares.

Cheers,
Gilles-Philippe Paillé